### PR TITLE
Fix merge commit message

### DIFF
--- a/ci-merge
+++ b/ci-merge
@@ -645,7 +645,7 @@ while read LINE; do
     echo "------------------------------------------"
     echo " ** Merging topic branch: $MERGER"
 
-    git merge -q --no-ff --no-edit $MERGER
+    git merge -q --no-ff --no-edit -m "Merge remote-tracking branch $REMOTE_NAME into $INTEG_BRANCH" $MERGER
     if [ $? -ne 0 ]; then
 	if [ $INTERACTIVE -eq 0 ]; then
             # try to commit, may be resolved by rerere


### PR DESCRIPTION
ci-merge appends remote branch to remote repository while merging corresponding topic branches.

Currently our configuration has detailed tech-specific remote name that matches with corresponding topic branch name, hence while merging it duplicates merge message like below.

 Merge remote-tracking branch 'tech/all/dt/qcs615/tech/all/dt/qcs615' into next

Update the git merge message to only consider remote branch name and integration branch while preparing merge message.